### PR TITLE
added BusKill 10% off on security kill cords

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ https://www.ifixit.com/promotions/black-friday-holiday
 Multiple On-Sale Kits \
 Deal Ends: November 28 
 
+BusKill (Magnetic Breakaway Dead Man Switch)
+https://buskill.in/
+Get 10% off all orders paid with cryptocurrency
+Deal ends: Dec 04
+
 ## Wearables:
 
 Security Merch (Merchandise for Hackers) \

--- a/README.md
+++ b/README.md
@@ -338,9 +338,9 @@ https://www.ifixit.com/promotions/black-friday-holiday
 Multiple On-Sale Kits \
 Deal Ends: November 28 
 
-BusKill (Magnetic Breakaway Dead Man Switch)
-https://buskill.in/
-Get 10% off all orders paid with cryptocurrency
+BusKill (Magnetic Breakaway Dead Man Switch) :see_no_evil: \
+https://buskill.in/  
+Get 10% off all orders paid with cryptocurrency \
 Deal ends: Dec 04
 
 ## Wearables:


### PR DESCRIPTION
Please add the following to your "hardware" section

```
BusKill (Magnetic Breakaway Dead Man Switch)
https://buskill.in/
Get 10% off all orders paid with cryptocurrency
Deal ends: Dec 04
```

## BusKill is 10% off

#### The Deal

BusKill's black friday deal is 10% off all products purchased between Nov 19 to Dec 04 2022.

No code is needed. The total will be reduced by 10% at checkout for all orders paid with cryptocurrencies.

 * https://www.buskill.in/bitcoin-black-friday-2022/

#### What is BusKill? How is it InfoSec Related?

BusKill is an open-source hardware and software project that uses a hardware tripwire/dead-man-switch (a usb cable with a magnetic breakaway) to trigger your computer to lock or shutdown if the user is physically separated from their machine.

 * https://en.wikipedia.org/wiki/BusKill

The following guide describes how BusKill can be configured to wipe the LUKS Header (containing the FDE key) and its metadata. It shows a video demo where the machine wiped the keys & powered-off in <6 seconds, and it includes a post-execution forensic analysis in Kali with bulk_extractor

 * https://www.buskill.in/luks-self-destruct/