### PR TITLE
add Cyber NOW + fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,14 +267,14 @@ Deal ends: 3rd December
 50% off Premium Plan ($224 down from $449) \
 Deal valid: 21st – 28th November
 
-**AppSecEngineer - Hands-on Training for AppSec/Cloud Security/AI Security/Kubernetes/DevSecOps/Threat Modeling**
-https://appsecengineer.com  
+**AppSecEngineer - Hands-on Training for AppSec/Cloud Security/AI Security/Kubernetes/DevSecOps/Threat Modeling** \
+https://appsecengineer.com  \
 40% off on Annual Plans with code `LEVELUP40` \
 Deal ends: 6th December
 
-**Cyber NOW Education - SOC analyst training including incident response, cloud security, REST API**
-[https://appsecengineer.com  ](https://www.cybernoweducation.com/subscribe)
-35% off on Lifetime member with code `CYBERHOLIDAY` \
+**Cyber NOW Education - SOC analyst training including incident response, cloud security, REST API** \
+[https://appsecengineer.com  ](https://www.cybernoweducation.com/subscribe) \
+35% off on Lifetime member with code `CYBERHOLIDAY` 
 
 ## Practical Labs
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ https://appsecengineer.com
 40% off on Annual Plans with code `LEVELUP40` \
 Deal ends: 6th December
 
+**Cyber NOW Education - SOC analyst training including incident response, cloud security, REST API**
+[https://appsecengineer.com  ](https://www.cybernoweducation.com/subscribe)
+35% off on Lifetime member with code `CYBERHOLIDAY` \
+
 ## Practical Labs
 
 **PentesterLab** - Practical pentesting & hacking Labs \


### PR DESCRIPTION
Fix missing \ after Modelling in AppSecEngineer


Cyber Now : 
Our course catalog features many of our courses, which have served over 30,000 students. Our flagship course, SOC Analyst NOW!, is based on the award-winning book Jump-start Your SOC Analyst Career, and Hack NOW! is based on the popular book Go Hack Yourself, where you learn to hack from a complete beginner.  

Our Knowledge Base is frequently added to the collection of premium text material, otherwise known as a blog, but I didn't want to call it that because it is so much more - it contains many labs and walkthroughs.  

Lastly, our webinar collection offers bite-sized tidbits of fun things to do and watch, all related to being a SOC analyst.

You can become a member here: https://www.cybernoweducation.com/subscribe

ENJOY 35% OFF LIFETIME MEMBERSHIPS TODAY with our only holiday sale.  Use coupon code "CYBERHOLIDAY" ($161)