### PR TITLE
Update README.md to change Deal valid to Deal ends for Security Onion wearables

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Deal valid: 17th November 2024 - 2nd January 2025
 **Security Onion** - Shirts and hats for defenders, blue teamers, threat hunters, and incident responders \
 https://securityonion.com/merch  
 25% off with code: `CYBERMONION24` \
-Deal valid: 24th December
+Deal ends: 24th December
 
 ## Books:
 


### PR DESCRIPTION
Thanks for merging the previous Security Onion PR! 

Since `Deal valid: Until December 24` was changed to `Deal valid: 24th December` after our PR, we should probably change that to `Deal ends: 24th December`. 

Thanks again!